### PR TITLE
Ruby geminde mesaj zamanlanamama bugı

### DIFF
--- a/lib/iletimerkezisms/sms.rb
+++ b/lib/iletimerkezisms/sms.rb
@@ -24,7 +24,7 @@ module IletimerkeziSMS
           }
           xlm.order {
             xlm.sender argv[:sender]
-            xlm.sendDateTime Time.now.strftime("%d/%m/%Y %H:%M")
+            xlm.sendDateTime argv[:sendDateTime]
             xlm.message {
               xlm.text_ argv[:message]
               xlm.receipents{

--- a/lib/iletimerkezisms/sms.rb
+++ b/lib/iletimerkezisms/sms.rb
@@ -24,7 +24,7 @@ module IletimerkeziSMS
           }
           xlm.order {
             xlm.sender argv[:sender]
-            xlm.sendDateTime argv[:sendDateTime]
+            xlm.sendDateTime Time.now.strftime("%d/%m/%Y %H:%M")
             xlm.message {
               xlm.text_ argv[:message]
               xlm.receipents{


### PR DESCRIPTION
Ruby geminde sendDateTime için Time.now kullanılmış, bu sebeple şeyi mesaj zamanlanamıyor. Bu pull request o hatayı düzeltiyor (date formatı koddan doğru bir şekilde format edilip sendDateTime'a verildiği sürece) 
Örnek kullanım:
message = params[:message]
    number = params[:number]
    sendDateTime = params[:sendDateTime]
    send_date_alert = params[:sendDateTime]

```
format = "%d/%m/%Y %H:%M"
sendDateTime = DateTime.strptime(sendDateTime, format)

argv = {
        :sender=>"ILETI MRKZI",
        :sendDateTime=> sendDateTime,
        :message=> message,
        :numbers=> [number]
        }

    sms = IletimerkeziSMS::SMS.new("isim", "şifre")
    sms.send(argv)
```

Ben kendi yarattığım repository'de test edemedim, nedense sizin kod da benim ki de çalışmıyor. Siz alıp test edin isterseniz.
